### PR TITLE
Fixes products not showing on main page.

### DIFF
--- a/front/html/index.html
+++ b/front/html/index.html
@@ -10,7 +10,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@100;200;300;400;500;600;700;800;900&display=swap" rel="stylesheet">
     <link href="../css/style.css" rel="stylesheet" />
-
+	<script src="../js/functions.js"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1">
   </head>
 
@@ -48,6 +48,9 @@
           <h2>Une gamme d'articles exclusifs</h2>
         </div>
         <section class="items" id="items"> 
+		<script>
+			getProducts();
+		</script>
         <!--
           <a href=products._id>
             <article>
@@ -83,6 +86,5 @@
         </div>
       </div>
     </footer>
-  <script src="../js/functions.js"></script>
   </body>
 </html>


### PR DESCRIPTION
There were no call made to getProducts() methods.
The script was declared at the bottom of the page making the call to getProducts() to fail (the DOM's loading was not completed when the call was made).